### PR TITLE
Add UIZZE affiliate program

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Share this list on [Twitter](https://twitter.com/intent/tweet?text=Check%20out%2
 - [binpress](http://www.binpress.com) - [affiliate information](http://www.binpress.com/content/affiliates) referral link
 - [Codecanyon](http://codecanyon.net) - [affiliate information](http://codecanyon.net/affiliate_program) referral link
 - [BCMS](https://thebcms.com) - [affiliate information](https://thebcms.com/affiliate)
+- [UIZZE](https://uizze.com) - [affiliate information](https://uizze.com/affiliates) - 50% of each referred buyer's first paid order; non-recurring; 30-day hold; manual payout. Public catalog is free; full access costs $9/month or $99 once.
 
 <a name="videos"></a> 
 ### Videos


### PR DESCRIPTION
## What changed

- Added UIZZE to the Code section with its official affiliate-program page.
- Included the exact commercial terms: 50% of each referred buyer's first paid order, non-recurring, with a 30-day hold and manual payout.
- Clarified that the public catalog is free and full access costs $9/month or $99 once.

## Why

UIZZE offers referral links for people who publish design, development, or coding-agent content, matching this list's purpose of helping app, blog, and site operators find monetization programs.

Disclosure: I am affiliated with UIZZE.

## Validation

- Confirmed there was no existing UIZZE entry, issue, or pull request.
- Confirmed both linked pages return HTTP 200.
- Ran `git diff --check` successfully.
